### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
Adding `.gitignore` to avoid tracking files that we don't need too such as `.DS_Store` that is created by OSX.
